### PR TITLE
nodeJS

### DIFF
--- a/tasks/browsers.yml
+++ b/tasks/browsers.yml
@@ -17,3 +17,11 @@
   sudo: yes
   apt:
     deb=/tmp/firefox-mozilla-build_34.0.5-0ubuntu1_amd64.deb\?r\=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fubuntuzilla%2Ffiles%2Fmozilla%2Fapt%2Fpool%2Fmain%2Ff%2Ffirefox-mozilla-build%2Ffirefox-mozilla-build_34.0.5-0ubuntu1_amd64.deb
+
+
+# PhantomJS
+- name: "Browsers: install PhantomJS"
+  sudo: yes
+  apt:
+    name=phantomjs
+    state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,11 @@
 # Pillow
 - include: pillow.yml
 
-# Node.js
-- include: nodejs.yml
-
 # Configure Jenkins user
 - include: user.yml
+
+# Node.js
+- include: nodejs.yml
 
 # Browsers (firefox, et al)
 - include: browsers.yml

--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -2,47 +2,71 @@
 
 - name: "node.js: fetch sources"
   sudo: yes
+  sudo_user: jenkins
   get_url:
     url=http://nodejs.org/dist/node-latest.tar.gz
     dest=/tmp/
 
 - name: "node.js: Unpack tarball"
   sudo: yes
+  sudo_user: jenkins
   command:
     tar zxf node-latest.tar.gz
     chdir=/tmp
 
 - name: "node.js: lookup directory name"
   sudo: yes
+  sudo_user: jenkins
   shell:
     ls /tmp | grep node-v
   register: node_dir
 
+- name: "user: create .local folder"
+  sudo: yes
+  sudo_user: jenkins
+  file:
+    path=/home/jenkins/.local
+    state=directory
+    owner=jenkins
+    group=jenkins
+
 - name: "node.js: configure"
   sudo: yes
+  sudo_user: jenkins
   shell:
-    ./configure --prefix=/usr/local
+    ./configure --prefix=/home/jenkins/.local
     chdir=/tmp/{{ node_dir.stdout }}
 
 - name: "node.js: make"
   sudo: yes
+  sudo_user: jenkins
   shell:
     /usr/bin/make
     chdir=/tmp/{{ node_dir.stdout }}
 
 - name: "node.js: make install"
   sudo: yes
+  sudo_user: jenkins
   shell:
     /usr/bin/make install
     chdir=/tmp/{{ node_dir.stdout }}
 
+# this is only useful when connecting to a node, Jenkins needs another tweak
+- name: "node.js: add nodejs on PATH"
+  sudo: yes
+  sudo_user: jenkins
+  shell:
+    echo "PATH=$PATH:/home/jenkins/.local/bin" >> /home/jenkins/.bashrc
+
 - name: "node.js: clean up node install"
   sudo: yes
+  sudo_user: jenkins
   shell:
     rm -rf /tmp/node-*
 
 - name: "node.js: install NPM packages"
   sudo: yes
+  sudo_user: jenkins
   npm:
     name={{item}}
     global=yes

--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -4,14 +4,14 @@
   sudo: yes
   sudo_user: jenkins
   get_url:
-    url=http://nodejs.org/dist/node-latest.tar.gz
+    url=http://nodejs.org/dist/v0.12.3/node-v0.12.3.tar.gz
     dest=/tmp/
 
 - name: "node.js: Unpack tarball"
   sudo: yes
   sudo_user: jenkins
   command:
-    tar zxf node-latest.tar.gz
+    tar zxf node-v0.12.3.tar.gz
     chdir=/tmp
 
 - name: "node.js: lookup directory name"


### PR DESCRIPTION
Trying to run mockup tests on a jenkins node (tried locally with [Vagrant](http://jenkinsploneorg.readthedocs.org/en/latest/vagrant.html)) showed that nodeJS current installation is completely broken.

For whichever reason nodeJS refuses to work if the user that tries to use it is different from the one that installed it.

This pull request changes the user that installs nodeJS from root to jenkins (the user that jenkins.plone.org uses on nodes).

Related to https://github.com/plone/jenkins.plone.org/issues/108
