### PR TITLE
Add jMeter

### DIFF
--- a/tasks/jmeter.yml
+++ b/tasks/jmeter.yml
@@ -1,0 +1,8 @@
+---
+# Install/configure everything related to jMeter
+
+- name: "jMeter: install"
+  sudo: yes
+  apt:
+    name=jmeter
+    state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,3 +23,6 @@
 
 # Browsers (firefox, et al)
 - include: browsers.yml
+
+# jMeter
+- include: jmeter.yml


### PR DESCRIPTION
So it can be used to run performance tests.

Already installed on all nodes.

One caveat though: as jMeter is installed from Ubuntu's 14.04 repositories, the version installed is 2.8.1. I see that jMeter 3.0 is out, and internally at der Freitag we used  to use 2.10.

@tisto any preference on jMeter version?
