### PR TITLE
Install Python 3.14.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,5 +21,6 @@ dependencies:
     python_311: true
     python_312: true
     python_313: true
+    python_314: true
     lxml: true
     pillow: true

--- a/roles.yml
+++ b/roles.yml
@@ -1,3 +1,3 @@
 ---
 - src: gforcada.compile_python
-  version: 6.5.1
+  version: 6.6.0


### PR DESCRIPTION
And use the updated Python versions from https://github.com/gforcada/ansible-compile-python/pull/30.

Note: you must do `ansible-galaxy install -r roles.yml --force` to use the new version of `gforcada/ansible-compile-python`, otherwise the `python_314` option is just ignored.

I am running this on my Jenkins node, although it has not finished yet, I am having some connection problems (I am not at home).  But should be fine.

cc @petschki 